### PR TITLE
Fixing bug where sub effects would lose their local positions.

### DIFF
--- a/timelinefx/source/TLFXEffect.cpp
+++ b/timelinefx/source/TLFXEffect.cpp
@@ -954,11 +954,6 @@ namespace TLFX
             _handleX = (int)(_currentWidth * 0.5f);
             _handleY = (int)(_currentHeight * 0.5f);
         }
-        else
-        {
-            _handleX = 0;
-            _handleY = 0;
-        }
 
         if (HasParticles() || _doesNotTimeout)
         {


### PR DESCRIPTION
An example effect for this bug is LibraryExamples.eff - "Monitor Readout". The positions of all the subeffects are incorrect.
