### PR TITLE
Fixing issue where particles were drawn out of order.

### DIFF
--- a/timelinefx/source/TLFXEffect.cpp
+++ b/timelinefx/source/TLFXEffect.cpp
@@ -1284,16 +1284,15 @@ namespace TLFX
 
         // the particle is managed by this Effect
         SetGroupParticles(true);
-        _inUse[layer].insert(p);
+		_inUse[layer].push_back(p);
+		p->SetIter(--_inUse[layer].end());
     }
 
     void Effect::RemoveInUse( int layer, Particle *p )
-    {
-        auto it = _inUse[layer].find(p);
+	{
+		auto it = p->GetIter();
         assert(layer >= 0 && layer < (int)_inUse.size() && it != _inUse[layer].end());
-
-        if (it != _inUse[layer].end())
-            _inUse[layer].erase(p);
+		_inUse[layer].erase(it);
     }
 
     int Effect::GetEffectLayer() const
@@ -1306,7 +1305,7 @@ namespace TLFX
         _effectLayer = layer;
     }
 
-    const std::set<Particle*>& Effect::GetParticles( int layer ) const
+    const ParticleList& Effect::GetParticles( int layer ) const
     {
         return _inUse[layer];
     }

--- a/timelinefx/source/TLFXEffect.h
+++ b/timelinefx/source/TLFXEffect.h
@@ -66,7 +66,7 @@
 #include <string>
 #include <map>
 #include <vector>
-#include <set>
+#include <list>
 
 namespace TLFX
 {
@@ -74,6 +74,8 @@ namespace TLFX
     class Particle;
     class ParticleManager;
     class Shape;
+	
+	typedef std::list<Particle*> ParticleList;
 
     class Effect : public Entity
     {
@@ -856,7 +858,7 @@ namespace TLFX
         void SetCurrentEffectFrame(float frame);
         float GetCurrentEffectFrame() const;
 
-        const std::set<Particle*>& GetParticles(int layer) const;
+        const ParticleList& GetParticles(int layer) const;
 
         bool IsDying() const;
 
@@ -892,7 +894,7 @@ namespace TLFX
         bool                           _allowSpawning;          /// Set to false to disable emitters from spawning any new particles
         float                          _ellipseArc;             /// With ellipse effects this sets the degrees of which particles emit around the edge
         int                            _ellipseOffset;          /// This is the offset needed to make arc center at the top of the circle.
-        std::vector<std::set<Particle*> > _inUse;               /// This stores particles created by the effect, for drawing purposes only.
+        std::vector<ParticleList>      _inUse;                  /// This stores particles created by the effect, for drawing purposes only.
         int                            _effectLayer;            /// The layer that the effect resides on in its particle manager
         bool                           _doesNotTimeout;         /// Whether the effect never timeouts automatically
 

--- a/timelinefx/source/TLFXParticle.cpp
+++ b/timelinefx/source/TLFXParticle.cpp
@@ -30,6 +30,7 @@ namespace TLFX
         , _layer(0)
         , _groupParticles(false)
         , _effectLayer(0)
+		// can't initialize _listIter without knowing what list this particle will be put into
     {
 
     }
@@ -108,6 +109,7 @@ namespace TLFX
         _gravity = 0;
         _weight = 0;
         _emitter = NULL;
+		// let _listIter stay an invalid iterator
     }
 
     void Particle::Destroy(bool releaseChildren)
@@ -283,5 +285,15 @@ namespace TLFX
     {
         return _weightVariation;
     }
+	
+	void Particle::SetIter(ParticleList::iterator iter)
+	{
+		_listIter = iter;
+	}
+	
+	ParticleList::iterator Particle::GetIter() const
+	{
+		return _listIter;
+	}
 
 } // namespace TLFX

--- a/timelinefx/source/TLFXParticle.h
+++ b/timelinefx/source/TLFXParticle.h
@@ -7,11 +7,16 @@
 
 #include "TLFXEntity.h"
 
+#include <list>
+
 namespace TLFX
 {
 
     class Emitter;
     class ParticleManager;
+	class Particle;
+	
+	typedef std::list<Particle*> ParticleList;
 
     /**
      * Particle Type - extends tlEntity
@@ -94,6 +99,9 @@ namespace TLFX
 
         void SetWeightVariation(float weightVar);
         float GetWeightVariation() const;
+		
+		void SetIter(ParticleList::iterator iter);
+		ParticleList::iterator GetIter() const;
 
     protected:
         Emitter*                    _emitter;                       // emitter it belongs to
@@ -119,6 +127,8 @@ namespace TLFX
         int                         _layer;                         // layer the particle belongs to
         bool                        _groupParticles;                // whether the particle is added the PM pool or kept in the emitter's pool
         int                         _effectLayer;
+		
+		ParticleList::iterator      _listIter;                      // for quick deletes from ParticleList
     };
 
 } // namespace TLFX

--- a/timelinefx/source/TLFXParticleManager.cpp
+++ b/timelinefx/source/TLFXParticleManager.cpp
@@ -152,7 +152,11 @@ namespace TLFX
             if (pool)
                 effect->AddInUse(layer, p);
             else
-                _inUse[effect->GetEffectLayer()][layer].insert(p);
+			{
+				auto& plist = _inUse[effect->GetEffectLayer()][layer];
+				plist.push_back(p);
+				p->SetIter(--plist.end());
+			}
 
             ++_inUseCount;
 
@@ -169,11 +173,7 @@ namespace TLFX
         if (!p->IsGroupParticles())
         {
             auto& plist = _inUse[p->GetEffectLayer()][p->GetLayer()];
-            auto it = plist.find(p);
-            if (it != plist.end())
-            {
-                plist.erase(it);
-            }
+			plist.erase(p->GetIter());
         }
     }
 

--- a/timelinefx/source/TLFXParticleManager.h
+++ b/timelinefx/source/TLFXParticleManager.h
@@ -10,6 +10,7 @@
 
 #include <vector>
 #include <set>
+#include <list>
 #include <stack>
 
 namespace TLFX
@@ -18,6 +19,8 @@ namespace TLFX
     class Particle;
     class Effect;
     class AnimImage;
+	
+	typedef std::list<Particle*> ParticleList;
 
     /**
      * Particle manager for managing a list of effects and all the emitters and particles they contain
@@ -255,7 +258,7 @@ namespace TLFX
         bool IsSpawningAllowed() const;
 
     protected:
-        std::vector<std::vector<std::set<Particle*> > > _inUse;
+        std::vector<std::vector<ParticleList> > _inUse;
         std::stack<Particle*>                _unused;
         int                                  _inUseCount;                           // the Particle doesn't have to be managed by ParticleManager (seed GrabParticle)
 


### PR DESCRIPTION
The intended order for particle raw is by age, oldest first. That way the newest particles appear on top. Since std::set is not sorted, the order was random. I replaced std::set with std::list and added a std::list::iterator to TLFX::Particles. The iterator is used when the particle is deleted so that the list does not need to be traversed first. std::list will offer constant time insert and delete this way.
A good example effect to see this issue is "Pyro/Fireball thick Smoke" from ExampleEffects.eff.
