### PR TITLE
Fixing issue with grid emission on a line.

### DIFF
--- a/timelinefx/source/TLFXEmitter.cpp
+++ b/timelinefx/source/TLFXEmitter.cpp
@@ -1136,7 +1136,7 @@ namespace TLFX
 
                                 if (_parentEffect->GetMGX() > 1)
                                 {
-                                    e->SetX((_gx / (_parentEffect->GetMGX() - 1) * _parentEffect->GetCurrentWidth()) - _parentEffect->GetHandleX());
+                                    e->SetX((_gx / static_cast<float>(_parentEffect->GetMGX() - 1) * _parentEffect->GetCurrentWidth()) - _parentEffect->GetHandleX());
                                 }
                                 else
                                 {


### PR DESCRIPTION
Particles would only be spawned at the beginning and end of a line.  Since _gx and mgx are both ints, the division was an integer division, but we need the result of a floating point division. Problem solved by casting part of the division to float.
To see this bug in action check out "Bar Readout" from "LibraryExamples.eff", specifically "Bar Readout/Container/Bars1".
