### PR TITLE
Allowing the number of particles that a manager has to grow at run timie

### DIFF
--- a/timelinefx/source/TLFXParticleManager.cpp
+++ b/timelinefx/source/TLFXParticleManager.cpp
@@ -10,8 +10,8 @@
 
 namespace TLFX
 {
-
     const int   ParticleManager::particleLimit = 5000;
+	bool        ParticleManager::createParticlesAsNeeded = true;
 
     ParticleManager::ParticleManager(int particles /*= particleLimit*/, int layers /*= 1*/)
         : _originX(0)
@@ -141,11 +141,19 @@ namespace TLFX
 
     Particle* ParticleManager::GrabParticle( Effect *effect, bool pool, int layer /*= 0*/ )
     {
+		Particle *p = NULL;
         if (!_unused.empty())
         {
-            Particle *p = _unused.top();
+            p = _unused.top();
             _unused.pop();
+		}
+		else if(createParticlesAsNeeded)
+		{
+			p = new Particle();
+		}
 
+		if(p)
+		{
             p->SetLayer(layer);
             p->SetGroupParticles(pool);
 

--- a/timelinefx/source/TLFXParticleManager.h
+++ b/timelinefx/source/TLFXParticleManager.h
@@ -64,6 +64,10 @@ namespace TLFX
     {
     public:
         static const int   particleLimit;
+		
+		// true: create particles whenever there aren't enough in _unused
+		// false: when _unused is empty, stop creating particles
+		static bool createParticlesAsNeeded;
 
         /**
          * Create a new Particle Manager


### PR DESCRIPTION
The number passed in to the ParticleManager constructor will now indicate the initial pool of particles and not a hard limit. This new functionality can be easily disabled by using the variable TLFX::ParticleManager::createParticlesAsNeeded.
