### PR TITLE
Adding a true global amount scale.

### DIFF
--- a/timelinefx/source/TLFXEmitter.cpp
+++ b/timelinefx/source/TLFXEmitter.cpp
@@ -865,7 +865,7 @@ namespace TLFX
         float curFrame = _parentEffect->GetCurrentEffectFrame();
         ParticleManager* pm = _parentEffect->GetParticleManager();
 
-        qty = ((GetEmitterAmount(curFrame) + Rnd(GetEmitterAmountVariation(curFrame))) * _parentEffect->GetCurrentAmount() * pm->GetGlobalAmountScale()) / EffectsLibrary::GetUpdateFrequency();
+        qty = ((GetEmitterAmount(curFrame) + Rnd(GetEmitterAmountVariation(curFrame))) * _parentEffect->GetCurrentAmount() * pm->GetGlobalAmountScale() * pm->GetLocalAmountScale()) / EffectsLibrary::GetUpdateFrequency();
         if (!_singleParticle)
             _counter += qty;
         intCounter = (int)_counter;

--- a/timelinefx/source/TLFXParticleManager.cpp
+++ b/timelinefx/source/TLFXParticleManager.cpp
@@ -12,6 +12,7 @@ namespace TLFX
 {
 
     const int   ParticleManager::particleLimit = 5000;
+	float       ParticleManager::_globalAmountScale = 1.0f;
 
     ParticleManager::ParticleManager(int particles /*= particleLimit*/, int layers /*= 1*/)
         : _originX(0)
@@ -40,7 +41,7 @@ namespace TLFX
 
         , _angleTweened(0)
 
-        , _globalAmountScale(1.0f)
+        , _localAmountScale(1.0f)
 
         , _camtx(0)
         , _camty(0)
@@ -314,17 +315,27 @@ namespace TLFX
     float ParticleManager::GetOriginZ() const
     {
         return _originZ;
-    }
-
-    float ParticleManager::GetGlobalAmountScale() const
-    {
-        return _globalAmountScale;
-    }
-
-    void ParticleManager::SetGlobalAmountScale( float scale )
-    {
-        _globalAmountScale = scale;
-    }
+	}
+	
+	float ParticleManager::GetLocalAmountScale() const
+	{
+		return _localAmountScale;
+	}
+	
+	void ParticleManager::SetLocalAmountScale( float scale )
+	{
+		_localAmountScale = scale;
+	}
+	
+	float ParticleManager::GetGlobalAmountScale()
+	{
+		return _globalAmountScale;
+	}
+	
+	void ParticleManager::SetGlobalAmountScale( float scale )
+	{
+		_globalAmountScale = scale;
+	}
 
     int ParticleManager::GetParticlesInUse() const
     {

--- a/timelinefx/source/TLFXParticleManager.h
+++ b/timelinefx/source/TLFXParticleManager.h
@@ -157,21 +157,36 @@ namespace TLFX
          * Get the current z origin/zoom factor of the particle manager
          */
         float GetOriginZ() const;
-
-        /**
-         * Get the globalamountscale value of the particle manager
-         * see #SetGlobalAmountScale for info about setting this value
-         */
-        float GetGlobalAmountScale() const;
-
-        /**
-         * Set the globalamountscale value of the particle manager
-         * Setting this value will scale the amount of the particles spawned by all emitters contained within the particle manager, making it a handy way
-         * to control globally, the amount of particles that are spawned. This can help improve performance on lower end hardware that struggle to draw
-         * lots of particles. A value of 1 (the default value) will spawn the default amount for each effect. A value of 0.5 though for example, will spawn
-         * half the amount of particles of each effect.
-         */
-        void SetGlobalAmountScale(float scale);
+		
+		/**
+		 * Get the localamountscale value of the particle manager
+		 * see #SetLocalAmountScale for info about setting this value
+		 */
+		float GetLocalAmountScale() const;
+		
+		/**
+		 * Set the localamountscale value of the particle manager
+		 * Setting this value will scale the amount of the particles spawned by all emitters contained within the particle manager, making it a handy way
+		 * to control globally, the amount of particles that are spawned. This can help improve performance on lower end hardware that struggle to draw
+		 * lots of particles. A value of 1 (the default value) will spawn the default amount for each effect. A value of 0.5 though for example, will spawn
+		 * half the amount of particles of each effect.
+		 */
+		void SetLocalAmountScale(float scale);
+		
+		/**
+		 * Get the globalamountscale value of all particle managers
+		 * see #SetGlobalAmountScale for info about setting this value
+		 */
+		static float GetGlobalAmountScale();
+		
+		/**
+		 * Set the globalamountscale value of the particle manager
+		 * Setting this value will scale the amount of the particles spawned by all emitters contained within all particle managers, making it a handy way
+		 * to control globally, the amount of particles that are spawned. This can help improve performance on lower end hardware that struggle to draw
+		 * lots of particles. A value of 1 (the default value) will spawn the default amount for each effect. A value of 0.5 though for example, will spawn
+		 * half the amount of particles of each effect.
+		 */
+		static void SetGlobalAmountScale(float scale);
 
         /**
          * Get the current number of particles in use
@@ -275,8 +290,9 @@ namespace TLFX
 
         float                                _tv, _tx, _ty, _tz, _px, _py;
         float                                _angleTweened;
-
-        float                                _globalAmountScale;
+		
+		float                                _localAmountScale; // only effects managed by this
+		static float                         _globalAmountScale; // all managers
 
         float                                _camtx, _camty, _camtz;
 


### PR DESCRIPTION
The old functionality of Get/SetGlobalAmountScale() can now be found in Get/SetLocalAmountScale(). The global version will now set a static member of TLFX::ParticleManager so that the change will effect all particle managers. The local version will effect only the current particle manager. This is useful in situations where there is more than one ParticleManager.
