### PR TITLE
fix particle relative angle

### DIFF
--- a/timelinefx/source/TLFXEmitter.cpp
+++ b/timelinefx/source/TLFXEmitter.cpp
@@ -1492,9 +1492,10 @@ namespace TLFX
                     _parentEffect->SetParticlesCreated(true);
 
                     // get the relative angle
-                    if (!_relative)
+                    if (!e->_relative)
                     {  // @todo dan Set(cosf(_angle  ??
-                        e->_matrix.Set(cosf(e->_angle / 180.0f * (float)M_PI), sinf(e->_angle / 180.0f * (float)M_PI), -sinf(e->_angle / 180.0f * (float)M_PI), cosf(e->_angle / 180.0f * (float)M_PI));
+                        float angle = _angle / 180.0f * (float)M_PI;
+                        e->_matrix.Set(cosf(angle), sinf(angle), -sinf(angle), cosf(angle));
                         e->_matrix = e->_matrix.Transform(_parent->GetMatrix());
                     }
                     e->_relativeAngle = _parent->GetRelativeAngle() + e->_angle;


### PR DESCRIPTION
get fix from original blitz code :
https://github.com/peterigz/rigz.mod/blob/03489168cf06c9a52e8f31508309b5da01cd6a80/timelinefx.mod/timelinefx.bmx#L4671

see Issue :  https://github.com/damucz/timelinefx/issues/16
